### PR TITLE
#2 fix double project loading on init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
 node_modules
 dist/js
 dist/css/reveal.js
+
+# IDE project files 
 .vscode
+*.code-workspace
+.idea/
+*.iml
+
+# OS specific
+.DS_Store

--- a/src/js/playback.js
+++ b/src/js/playback.js
@@ -328,8 +328,8 @@ export class Playback {
         this.playingLog = null;
         this.recorder = this.snapWindow.recorder;
         if (this.snapWindow.recorder) {
-            this.recorder.constructor.resetSnap(this.script.startXML);
             this.recorder.constructor.setRecordScale(this.script.config.blockScale);
+            this.recorder.constructor.resetSnap(this.script.startXML);
             this.recorder.constructor.setOnClickCallback(
                 (x, y) => this.clickHighlight.trigger(x, y));
         }


### PR DESCRIPTION
Since changing block scale reloads the IDE it is a good idea to call it first, then load the project from start.xml. Fixes #2 